### PR TITLE
fix: make _notification_handler a normal function

### DIFF
--- a/src/bonaparte/device.py
+++ b/src/bonaparte/device.py
@@ -276,7 +276,7 @@ class EfireDevice:
             msg = f"Invalid fooer {message[-1]}. Message should end with {FOOTER}."
             raise EfireMessageValueError(msg)
 
-    async def _notification_handler(
+    def _notification_handler(
         self, _char: BleakGATTCharacteristic, message: bytearray
     ) -> None:
         _LOGGER.debug(


### PR DESCRIPTION
Nothing is being awaited here and by making it a coro, each notification has to [spawn a new task](https://github.com/hbldh/bleak/blob/74a937c71e840d5f78647742bfe9a41084b305f7/bleak/__init__.py#L836) which has to wait one iteration of the event loop and increases latancy